### PR TITLE
サインアップ、ログイン機能の実装

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -17,7 +17,7 @@
                 <form action="/login" method="post">
                     <div>
                         <label class="item-name" for="name">ユーザー名</label>
-                        <input class="text" type="text" id="name" name="username">
+                        <input class="text" type="text" id="username" name="username">
                     </div>
                     <div>
                         <label class="item-name" for="password">パスワード</label>

--- a/server/login.rb
+++ b/server/login.rb
@@ -1,64 +1,32 @@
-require_relative 'top.rb'
+# require_relative 'top.rb'
 
-require 'webrick'
-require 'mysql2'
-require 'digest'
+# require 'webrick'
+# require 'mysql2'
+# require 'digest'
 
-$db_client = Mysql2::Client.new(
-    host: 'localhost',
-    username: 'root',
-    password: '@ZSExdr123',
-    database: 'study_record'
-)
+# $db_client = Mysql2::Client.new(
+#     host: 'localhost',
+#     username: 'root',
+#     password: '@ZSExdr123',
+#     database: 'study_record'
+# )
 
-# パスワードをハッシュ化するメソッド
-def hash_password(password)
-    Digest::SHA256.hexdigest(password)
-end
+# # ポート3000でWEBrick HTTPサーバーを作成
+# server = WEBrick::HTTPServer.new(Port: 3000)
 
-# データベースからユーザーを検索するメソッド
-def find_user(username, password)
-    hashed_password = hash_password(password)
-    query = "SELECT * FROM users WHERE username = ? AND password = ?"
-    result = $db_client.query(query, username, hashed_password)
-    result.first
-end
+# # '/login'画面
+# server.mount_proc '/login' do |req, res|
+#     res.content_type = 'text/html'
+    
+#     html_file_path = '../pages/login.html'  # ファイルの実際のパスに変更してください
+#     html_content = File.read(html_file_path)
+    
+#     res.body = html_content
+# end
 
-# ポート3000でWEBrick HTTPサーバーを作成
-server = WEBrick::HTTPServer.new(Port: 3000)
 
-# 割り込みシグナルを受け取ってサーバーをシャットダウン
-trap('INT') { server.shutdown }
 
-# ERBハンドラを使用してloginページを提供
-server.mount('/login.html', WEBrick::HTTPServlet::ERBHandler, 'study_record/pages/login.html')
-
-# 'assets'ディレクトリから静的なアセットを提供
-server.mount('/assets', WEBrick::HTTPServlet::FileHandler, File.join(Dir.pwd, '../assets'))
-
-# '/login'エンドポイントへのPOSTリクエストを処理
-server.mount_proc('/login') do |req, res|
-    puts "aaa"
-    if req.request_method == 'POST'
-        # リクエストボディからパラメータを解析
-        params = WEBrick::HTTPUtils.parse_query(req.body)
-        username = params['name']
-        password = params['password']
-
-        # データベースからユーザーを検索
-        user = find_user(username, password)
-
-        if user
-        # ログイン成功時の処理
-        res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/home')
-        else
-        # ログイン失敗時の処理
-        res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/top')
-        end
-    else
-        # リクエストメソッドがPOSTでない場合はエラーレスポンスを設定
-        res.body = '無効なリクエストです'
-    end
-end
-
-# WEBrick HTTPサーバーを起動
+# # 割り込みシグナルを受け取ってサーバーをシャットダウン
+# trap('INT') { server.shutdown }
+# # WEBrick HTTPサーバーを起動
+# server.start

--- a/server/signup.rb
+++ b/server/signup.rb
@@ -4,7 +4,7 @@ require 'webrick'
 require 'mysql2'
 require 'digest'
 
-$db_client = Mysql2::Client.new(
+db_client = Mysql2::Client.new(
   host: 'localhost',       # 全員、localhostでOKです
   username: 'root',        # ひとまず、権限を一番持っているrootユーザーにしました
   password: '0606araki',   # 自身のmysqlのrootユーザーのパスワードをここに入力します
@@ -20,7 +20,7 @@ def save_user_to_database(username, password)
     # 'users'テーブルにユーザデータを挿入するSQLクエリを構築し実行（How_to_Signupで解説）
     hashed_password = Digest::SHA256.hexdigest(password)
     insert_query = "INSERT INTO users (username, password) VALUES (?, ?)"
-    $db_client.query(insert_query, username, password)
+    db_client.query(insert_query, username, password)
     return true
   end
 end
@@ -47,10 +47,10 @@ server.mount_proc('/signup') do |req, res|
     # save_user_to_databaseメソッドを呼び出してユーザデータをデータベースに挿入
     if save_user_to_database(username, password)
       # サインアップの処理が成功したら'/home'のURLにリダイレクト
-      res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/home')
+      res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/home.html')
     else
       # ユーザー名またはパスワードが空の場合は前のページにリダイレクト
-      res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/top')
+      res.set_redirect(WEBrick::HTTPStatus::SeeOther, '/top.html')
     end
   else
     # リクエストメソッドがPOSTでない場合はエラーレスポンスを設定

--- a/server/top.rb
+++ b/server/top.rb
@@ -1,19 +1,19 @@
-# top.rb
+# # top.rb
 
-require 'webrick'
+# require 'webrick'
 
-server = WEBrick::HTTPServer.new(Port: 3000)
+# server = WEBrick::HTTPServer.new(Port: 3000)
 
-trap('INT') { server.shutdown }
+# trap('INT') { server.shutdown }
 
-# ERBハンドラを使用してtopページを提供
-server.mount('/', WEBrick::HTTPServlet::ERBHandler, '../pages/top.html')
+# # ERBハンドラを使用してtopページを提供
+# server.mount('/', WEBrick::HTTPServlet::ERBHandler, '../pages/top.html')
 
-server.mount('/signup.html', WEBrick::HTTPServlet::ERBHandler, '../pages/signup.html')
+# server.mount('/signup.html', WEBrick::HTTPServlet::ERBHandler, '../pages/signup.html')
 
-server.mount('/login.html', WEBrick::HTTPServlet::ERBHandler, '../pages/login.html')
+# server.mount('/login.html', WEBrick::HTTPServlet::ERBHandler, '../pages/login.html')
 
-# 'assets'ディレクトリから静的なアセットを提供
-server.mount('/assets', WEBrick::HTTPServlet::FileHandler, File.join(Dir.pwd, '../assets'))
+# # 'assets'ディレクトリから静的なアセットを提供
+# server.mount('/assets', WEBrick::HTTPServlet::FileHandler, File.join(Dir.pwd, '../assets'))
 
-server.start
+# server.start


### PR DESCRIPTION
 #webrick.rb 55.  params = req.body.split('&').map { |pair| pair.split('=') }.to_h #むず処理
* webrick.rbの52行目ログイン機能の処理で paramsを使用してlogin.htmlのaction = /login のname属性 username と password を取得しようとしたところ、正しく処理できませんでした。putsを使いコンソールで確認すると、理由は不明だが(webrickの仕様？)　username = *** & password = *** というキモい形で取得されていたのでusernameとpasswordを分解しています。


#webrick.rb 106. encoding: 'utf8' # 追加
* これはデータベースに保存されたusernameが%E3%81%8C%E3%82%93%のように文字列がURLエンコードされた状態でデータベースに保存されてしまっています。そのため文字エンコーディングを適切に指定する必要があり、その処理です。

ログイン、サインアップの流れはコードを見てください。どっちかが分かれば逆のことするだけです。