### PR TITLE
日報一覧から編集ページへの遷移を追加

### DIFF
--- a/js/get_edit_report.js
+++ b/js/get_edit_report.js
@@ -1,0 +1,27 @@
+document.querySelectorAll('.styled.edit').forEach(function(editButton) {
+  editButton.addEventListener('click', function() {
+    // クリックされたボタンに関連する記事のIDを取得
+    var reportId = this.getAttribute('data-report-id');
+
+    // Ajaxリクエストを行う
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', '/get_edit_report?report_id=' + reportId, true);
+
+    xhr.onreadystatechange = function() {
+      if (xhr.readyState == 4) {
+        if (xhr.status == 200) {
+          // レスポンスの処理を行う
+          console.log(xhr.responseText);
+          
+          // レスポンスを受けたら編集ページに遷移する
+          window.location.href = 'http://localhost:3000/edit_diary.html?report_id=' + reportId;
+        } else {
+          // エラー時の処理をここに追加
+          console.error('Failed to get edit report. Status code: ' + xhr.status);
+        }
+      }
+    };
+
+    xhr.send();
+  });
+});

--- a/js/my_page.js
+++ b/js/my_page.js
@@ -1,0 +1,48 @@
+fetch("/after_header.html")
+.then((response) => response.text())
+.then((data) => document.querySelector("#header").innerHTML = data);
+
+let deleteButtons = document.querySelectorAll('.styled[value="削除"]');
+
+// NodeList内の各要素に対してループをかける
+deleteButtons.forEach(function(button) {
+  button.addEventListener('click', function(event) {
+    var infoList = findAncestor(event.target, 'info-list');
+
+      if (infoList) {
+        var infoListId = infoList.getAttribute('id');
+        var isConfirmed = confirm("本当に削除しますか？");
+
+        if (isConfirmed) {
+          // "はい" が押された場合に deleteDatabase 関数を実行
+          deleteDatabase(infoListId);
+        }
+    }
+  });
+});
+
+// 指定されたクラス名を持つ親要素を検索する関数
+function findAncestor(element, className) {
+  while ((element = element.parentElement) && !element.classList.contains(className));
+  return element;
+}
+
+function deleteDatabase(infoListId) {
+  let xhr = new XMLHttpRequest();
+
+  xhr.open('GET', '/delete_request?id=' + encodeURIComponent(infoListId), true);
+
+  xhr.onload = function() {
+    if (xhr.status >= 200 && xhr.status < 300) {
+        // 成功時の処理
+        console.log('データベースから削除されました。ページをリロードします。');
+        location.reload();
+    } else {
+        // エラー時の処理
+        console.error('失敗');
+    }
+};
+
+  xhr.send();
+}
+

--- a/pages/diary_list.html
+++ b/pages/diary_list.html
@@ -10,28 +10,312 @@
 <body>
     <header id="header"></header>
     <main><h1 class="title">日報一覧</h1>
-        <div class="info-list" id="8">
+        <div class="info-list" id="23">
             <div class="top-items">
                 <ul class="left-item">
                     <li><h4>【日付】<br>2024-01-28</h4></li>
-                    <li><h4>【名前】<br>jojo</h4></li>
-                    <li><h4>【学習時間】<br>14</h4></li>
-                    <li><h6>【投稿日時】:2024-01-28 01:37:42 +0900</h6></li>
+                    <li><h4>【名前】<br>GoIshikawa</h4></li>
+                    <li><h4>【学習時間】<br>8</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 09:54:35 +0900</h6></li>
                 </ul>
                 <ul class="right-item">
                     <h3>【学習内容】<h3>
-                    <li><h5>ほぼ完成！</h5></li>
+                    <li><h5>チーム開発　paiza</h5></li>
                 </ul>
             </div>
             <div class="bottom-items">
                 <div class="text-content">
                     <h3>【振り返り】</h3>
-                    <p>楽しかった！
-</p>
+                    <p>チーム開発を通して開発に関しての理解が深まった。技術だけでなく開発がどのような流れで行われるかが分かっていい機会をいただいたと思った。また、実際に動かしてみないと技術が身につかないこともよく分かったので、チーム開発で得られたことを無駄にせずこれからも頑張っていきたい。</p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="23">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="22">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>RemuAraki</h4></li>
+                    <li><h4>【学習時間】<br>14</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 09:46:50 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>チーム開発</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>だいぶ時間がかかりましたが、ほぼほぼ完成まで持っていくことができました！嬉しい気持ちでいっぱいです。今回のチーム開発では学んだことが多すぎて整理するのが大変です。だいぶ上達した気がします。残された時間はあと少しですが、引き続き全力で取り組みたいです！</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="22">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="21">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>RikuKawashima</h4></li>
+                    <li><h4>【学習時間】<br>9</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 09:42:55 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>AtCoder、チーム開発</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>チーム開発もあと2日ということでチーム開発が始まる前の予定より大幅に遅れてしまっていましたが何とか形になっていてすごくうれしいです。初めてのチーム開発でわからないことしかない中チームメンバーの人たちと話し合って開発するのはとても大変でしたが楽しかったです。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="21">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="19">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>Momotaro</h4></li>
+                    <li><h4>【学習時間】<br>9</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 00:22:21 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・お供を見つける
+・鬼が島に行く
+・鬼を退治する</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>鬼から宝を奪って村の人たちに配り歩くという行為が、令和の時代では不適切にあたるため、「あなたの話はあまり好まれなくなった」と言われました。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="19">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="18">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>JALJAL</h4></li>
+                    <li><h4>【学習時間】<br>13</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 00:13:56 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・国名わけっこという遊びを作る</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>「イタ？」「リア」「ドイ？」「ツ」「アメ？」「リカ」「アル？」「ゼンチン」「イン？」「ドネシア」「アルインアルイン？」「ゼンチンドネシアゼンチンドネシア」</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="18">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="17">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>NONSTYLE</h4></li>
+                    <li><h4>【学習時間】<br>5</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 00:10:09 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・井上さんの良い所を見つける</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>石田「・・・歯並び。」</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="17">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="16">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-28</h4></li>
+                    <li><h4>【名前】<br>MilkBoy</h4></li>
+                    <li><h4>【学習時間】<br>10</h4></li>
+                    <li><h6>【投稿日時】:2024-01-28 00:02:51 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・オカンが忘れた朝ご飯を思い出す</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>オカンが朝ご飯の名前を忘れました。
+カリカリしていて、牛乳などをかけて食べるやつです。
+晩ご飯で出てきても良いです。
+栄養バランスの五角形デカイです。
+お坊さんが修行のときも食べています。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="16">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="14">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Urashimataro</h4></li>
+                    <li><h4>【学習時間】<br>7</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 21:27:01 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・玉手箱を開けるかどうするか</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>ついに、開けることにしました。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="14">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="13">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>HiroyukiNarita</h4></li>
+                    <li><h4>【学習時間】<br>0</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 21:11:11 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・当たり前のことを名言っぽく言う</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>生きるというのは、朝起きて夜眠るまで、繰り返される当たり前の瞬間の連続である。日々の生活は、決して大きなドラマや驚きに満ちているわけではない。むしろ、単調で平凡な日常が私たちを取り巻いている。朝食を食べ、仕事や学業に励み、そして夜は休息をとる。これらの行動は誰もが当たり前に繰り返していることだ。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="13">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="12">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Urashimataro</h4></li>
+                    <li><h4>【学習時間】<br>20</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 21:06:10 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>・いじめられた亀を助ける
+・竜宮城に行く
+・さんざん楽しむ
+・玉手箱をもらう
+</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>もらった玉手箱をどうしようか、ずっと悩んでいます。</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="12">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="11">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>14</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:53:06 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>お前はもう・・・</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="11">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="8">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>15</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:35:59 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>アタタタタタタタタアアアアー</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="8">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>
@@ -39,24 +323,49 @@
         <div class="info-list" id="7">
             <div class="top-items">
                 <ul class="left-item">
-                    <li><h4>【日付】<br>2024-01-25</h4></li>
-                    <li><h4>【名前】<br>user1</h4></li>
-                    <li><h4>【学習時間】<br>150</h4></li>
-                    <li><h6>【投稿日時】:2024-01-28 00:00:16 +0900</h6></li>
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>14</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:25:52 +0900</h6></li>
                 </ul>
                 <ul class="right-item">
                     <h3>【学習内容】<h3>
-                    <li><h5>データベース設計</h5></li>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
                 </ul>
             </div>
             <div class="bottom-items">
                 <div class="text-content">
                     <h3>【振り返り】</h3>
-                    <p>難しいが理解できました。</p>
+                    <p>押しても、もう</p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="7">
+                <input class="styled" type="button" value="削除" id="delete">
+                </div>
+            </div>
+        </div>
+    
+        <div class="info-list" id="6">
+            <div class="top-items">
+                <ul class="left-item">
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>24</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:24:28 +0900</h6></li>
+                </ul>
+                <ul class="right-item">
+                    <h3>【学習内容】<h3>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
+                </ul>
+            </div>
+            <div class="bottom-items">
+                <div class="text-content">
+                    <h3>【振り返り】</h3>
+                    <p>お前はもう</p>
+                </div>
+                <div class="buttons">
+                <input class="styled edit" type="button" value="編集" data-report-id="6">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>
@@ -65,23 +374,23 @@
             <div class="top-items">
                 <ul class="left-item">
                     <li><h4>【日付】<br>2024-01-27</h4></li>
-                    <li><h4>【名前】<br>user1</h4></li>
-                    <li><h4>【学習時間】<br>6</h4></li>
-                    <li><h6>【投稿日時】:2024-01-27 23:38:24 +0900</h6></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>24</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:20:03 +0900</h6></li>
                 </ul>
                 <ul class="right-item">
                     <h3>【学習内容】<h3>
-                    <li><h5>pppppppp</h5></li>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
                 </ul>
             </div>
             <div class="bottom-items">
                 <div class="text-content">
                     <h3>【振り返り】</h3>
-                    <p>aaaaa</p>
+                    <p>お前はもう</p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="4">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>
@@ -89,49 +398,24 @@
         <div class="info-list" id="3">
             <div class="top-items">
                 <ul class="left-item">
-                    <li><h4>【日付】<br>2024-01-29</h4></li>
-                    <li><h4>【名前】<br>user2</h4></li>
-                    <li><h4>【学習時間】<br>3</h4></li>
-                    <li><h6>【投稿日時】:2024-01-27 20:39:58 +0900</h6></li>
+                    <li><h4>【日付】<br>2024-01-27</h4></li>
+                    <li><h4>【名前】<br>Kenshiro</h4></li>
+                    <li><h4>【学習時間】<br>15</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 20:17:51 +0900</h6></li>
                 </ul>
                 <ul class="right-item">
                     <h3>【学習内容】<h3>
-                    <li><h5>Web開発</h5></li>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
                 </ul>
             </div>
             <div class="bottom-items">
                 <div class="text-content">
                     <h3>【振り返り】</h3>
-                    <p>HTML、CSS、JavaScriptのプロジェクトに取り組みました。</p>
+                    <p>お前はもう、しんでいる</p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
-                </div>
-            </div>
-        </div>
-    
-        <div class="info-list" id="2">
-            <div class="top-items">
-                <ul class="left-item">
-                    <li><h4>【日付】<br>2024-01-28</h4></li>
-                    <li><h4>【名前】<br>user2</h4></li>
-                    <li><h4>【学習時間】<br>2</h4></li>
-                    <li><h6>【投稿日時】:2024-01-27 20:39:58 +0900</h6></li>
-                </ul>
-                <ul class="right-item">
-                    <h3>【学習内容】<h3>
-                    <li><h5>データベース基礎</h5></li>
-                </ul>
-            </div>
-            <div class="bottom-items">
-                <div class="text-content">
-                    <h3>【振り返り】</h3>
-                    <p>SQLクエリとデータベース設計を探求しました。</p>
-                </div>
-                <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="3">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>
@@ -140,27 +424,28 @@
             <div class="top-items">
                 <ul class="left-item">
                     <li><h4>【日付】<br>2024-01-27</h4></li>
-                    <li><h4>【名前】<br>user2</h4></li>
-                    <li><h4>【学習時間】<br>3</h4></li>
-                    <li><h6>【投稿日時】:2024-01-27 20:39:58 +0900</h6></li>
+                    <li><h4>【名前】<br>Momotaro</h4></li>
+                    <li><h4>【学習時間】<br>24</h4></li>
+                    <li><h6>【投稿日時】:2024-01-27 19:35:39 +0900</h6></li>
                 </ul>
                 <ul class="right-item">
                     <h3>【学習内容】<h3>
-                    <li><h5>プログラミング基礎</h5></li>
+                    <li><h5>アタタタタタタタタアアアアー</h5></li>
                 </ul>
             </div>
             <div class="bottom-items">
                 <div class="text-content">
                     <h3>【振り返り】</h3>
-                    <p>変数と制御構造について学びました。</p>
+                    <p>お前はもう、しんでいる</p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="1">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>
     </main>
     <script src="../js/diary_list.js"></script>
+    <script src="../js/get_edit_report.js"></script>
 </body>
 </html>

--- a/pages/edit_diary.html
+++ b/pages/edit_diary.html
@@ -14,7 +14,7 @@
                 <h1>日報を編集する</h1>
             </div>
             <div class="form-wrapper">
-                <form action="/edit_report" method="post" id="post_diary">
+                <form action="/post_edit_report" method="post" id="post_diary">
                     <div>
                         <label class="item-name date" for="name">日にち</label>
                         <input class="text" type="date" id="today" name="date">
@@ -67,6 +67,6 @@
             <input class="submit" type="submit" value="投稿する" form="post_diary">
         </div>
     </div>
-    <script src="../js/edit_diary.js"></script>
+    <!-- <script src="../js/edit_diary.js"></script> -->
 </body>
 </html>

--- a/pages/my_page.html
+++ b/pages/my_page.html
@@ -10,23 +10,862 @@
 <body>
     <header id="header"></header>
     <main><h1 class="title">マイページ</h1>
-            <div class="info-list" id="8">
+            <div class="info-list" id="11">
                 <div class="top-items">
                     <ul class="left-item">
-                        <li><h4>日付<br>2024-01-28</h4></li>
+                        <li><h4>日付<br>2024-01-27</h4></li>
                         <li><h4>学習時間<br>14</h4></li>
-                        <li><h6>投稿日時:2024-01-28 01:37:42 +0900</h6></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
                     </ul>
                     <ul class="right-item">
                         <h3>学習内容<h3>
-                        <li><h5>ほぼ完成！</h5></li>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
                     </ul>
                 </div>
                 <div class="bottom-items">
                     <div class="text-content">
                         <h3>振り返り</h3>
-                        <p>楽しかった！
-</p>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="11">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="11">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="11">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="11">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="11">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:53:06 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう・・・</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="8">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:35:59 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>アタタタタタタタタアアアアー</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="7">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>14</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:25:52 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>押しても、もう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="6">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:24:28 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="4">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>24</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:20:03 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう</p>
+                    </div>
+                    <div class="buttons">
+                        <input class="styled" type="button" value="編集" id="edit">
+                        <input class="styled" type="button" value="削除" id="delete">
+                    </div>
+                </div>
+            </div>
+        
+            <div class="info-list" id="3">
+                <div class="top-items">
+                    <ul class="left-item">
+                        <li><h4>日付<br>2024-01-27</h4></li>
+                        <li><h4>学習時間<br>15</h4></li>
+                        <li><h6>投稿日時:2024-01-27 20:17:51 +0900</h6></li>
+                    </ul>
+                    <ul class="right-item">
+                        <h3>学習内容<h3>
+                        <li><h5>アタタタタタタタタアアアアー</h5></li>
+                    </ul>
+                </div>
+                <div class="bottom-items">
+                    <div class="text-content">
+                        <h3>振り返り</h3>
+                        <p>お前はもう、しんでいる</p>
                     </div>
                     <div class="buttons">
                         <input class="styled" type="button" value="編集" id="edit">
@@ -35,6 +874,6 @@
                 </div>
             </div>
         </main>
-    <script src="../js/diary_list.js"></script>
+    <script src="../js/my_page.js"></script>
 </body>
 </html>

--- a/server/diary_list.rb
+++ b/server/diary_list.rb
@@ -7,7 +7,7 @@ require 'erb'
 client = Mysql2::Client.new(
     host: "localhost", 
     username: "root", 
-    password: '0606araki', 
+    password: '　　　　　', 
     database: 'study_record',
 )
 
@@ -18,6 +18,7 @@ test = File.read("../pages/diary_list.html")
 result = client.query("SELECT * FROM reports ORDER BY report_id DESC")
 
 # reportsテーブルから持ってきたカラムを配列で取得
+report_id = result.map { |row| row['report_id'] } # 編集ボタンを対応させるために追加
 date = result.map { |row| row['date'] }
 study_time = result.map { |row| row['study_time'] }
 created_time = result.map { |row| row['created_at'] }
@@ -60,8 +61,8 @@ while num < data_count do
                     <p><%= reflection[num] %></p>
                 </div>
                 <div class="buttons">
-                    <input class="styled edit" type="button" value="編集" id="edit">
-                    <input class="styled" type="button" value="削除" id="delete">
+                <input class="styled edit" type="button" value="編集" data-report-id="<%= report_id[num] %>">
+                <input class="styled" type="button" value="削除" id="delete">
                 </div>
             </div>
         </div>


### PR DESCRIPTION
WEBrickに追記

【日報一覧から編集ボタンを押したとき】
　server.mount_proc '/get_edit_report' do |req, res|

【日報一覧ページの表示】
server.mount_proc '/edit_diary.html do |req, res|

【日報一覧ページから「投稿する」を押したとき】（作成中）
server.mount_proc '/post_edit_report' do |req, res|


※トップ画面とホーム画面と日報一覧のCSS（背景画像）が崩れてしまいました！すみません！！！
